### PR TITLE
Change ace library CDN link

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -47,7 +47,7 @@
         <div id="output"></div>
         
         <script src="../client.js"></script>
-        <script src="http://d1n0x3qji82z53.cloudfront.net/src-min-noconflict/ace.js" type="text/javascript" charset="utf-8"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.2.8/ace.js" type="text/javascript" charset="utf-8"></script>
         <script>
             
             // Setup Editor


### PR DESCRIPTION
Cloudfront ace link is not working anymore. Change to cdnjs.